### PR TITLE
Fix undefined location length in flow sorting

### DIFF
--- a/api/filtered_flow.js
+++ b/api/filtered_flow.js
@@ -148,7 +148,15 @@ module.exports = async (req, res) => {
 
         // Sort and filter to get the top 5 results
         const finalResults = await Promise.all(filteredResults);
-        const sortedResults = finalResults.sort((a, b) => b.currentFlow.jamFactor - a.currentFlow.jamFactor || b.location.length - a.location.length).slice(0, 5);
+        const sortedResults = finalResults
+            .sort((a, b) => {
+                const jamDiff = b.currentFlow.jamFactor - a.currentFlow.jamFactor;
+                if (jamDiff !== 0) return jamDiff;
+                const aLen = a.location && a.location.length ? a.location.length : 0;
+                const bLen = b.location && b.location.length ? b.location.length : 0;
+                return bLen - aLen;
+            })
+            .slice(0, 5);
 
         results.push({
             bbox: bbox,


### PR DESCRIPTION
## Summary
- handle missing `location.length` when sorting results in `filtered_flow.js`

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_68418408f0dc8324ae9f4edd38663f9c